### PR TITLE
66: Tidy up of the payment related ConsentDetailsService classes

### DIFF
--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/DomesticPaymentConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/DomesticPaymentConsentDecisionService.java
@@ -21,11 +21,16 @@ import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRD
 import org.springframework.stereotype.Service;
 
 @Service
-public class DomesticPaymentConsentDecisionService extends PaymentConsentDecisionService<FRDomesticPaymentConsent> {
+public class DomesticPaymentConsentDecisionService extends PaymentConsentDecisionService {
 
     public DomesticPaymentConsentDecisionService(PaymentConsentService paymentConsentService,
                                                  ObjectMapper objectMapper,
                                                  PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
-        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater, FRDomesticPaymentConsent.class);
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRDomesticPaymentConsent> getConsentClass() {
+        return FRDomesticPaymentConsent.class;
     }
 }

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/DomesticScheduledPaymentConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/DomesticScheduledPaymentConsentDecisionService.java
@@ -21,11 +21,16 @@ import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRD
 import org.springframework.stereotype.Service;
 
 @Service
-public class DomesticScheduledPaymentConsentDecisionService extends PaymentConsentDecisionService<FRDomesticScheduledPaymentConsent> {
+public class DomesticScheduledPaymentConsentDecisionService extends PaymentConsentDecisionService {
 
     public DomesticScheduledPaymentConsentDecisionService(PaymentConsentService paymentConsentService,
                                                           ObjectMapper objectMapper,
                                                           PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
-        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater, FRDomesticScheduledPaymentConsent.class);
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRDomesticScheduledPaymentConsent> getConsentClass() {
+        return FRDomesticScheduledPaymentConsent.class;
     }
 }

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/DomesticStandingOrderConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/DomesticStandingOrderConsentDecisionService.java
@@ -21,11 +21,16 @@ import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRD
 import org.springframework.stereotype.Service;
 
 @Service
-public class DomesticStandingOrderConsentDecisionService extends PaymentConsentDecisionService<FRDomesticStandingOrderConsent> {
+public class DomesticStandingOrderConsentDecisionService extends PaymentConsentDecisionService {
 
     public DomesticStandingOrderConsentDecisionService(PaymentConsentService paymentConsentService,
-                                                          ObjectMapper objectMapper,
-                                                          PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
-        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater, FRDomesticStandingOrderConsent.class);
+                                                       ObjectMapper objectMapper,
+                                                       PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRDomesticStandingOrderConsent> getConsentClass() {
+        return FRDomesticStandingOrderConsent.class;
     }
 }

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticPaymentConsentDetailsService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticPaymentConsentDetailsService.java
@@ -17,12 +17,11 @@ package com.forgerock.securebanking.openbanking.uk.rcs.service.detail;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.tpp.Tpp;
-import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
+import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.ConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.DomesticPaymentConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.TppService;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRDomesticPaymentConsent;
-import com.forgerock.securebanking.openbanking.uk.rcs.exception.InvalidConsentException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
@@ -32,77 +31,45 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.FRAmountConverter.toFRAmount;
-import static com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType.*;
-import static com.forgerock.securebanking.openbanking.uk.rcs.util.AccountWithBalanceMatcher.getMatchingAccount;
-import static java.util.Collections.emptyList;
 
 @Service
 @Slf4j
-public class DomesticPaymentConsentDetailsService implements ConsentDetailsService {
+public class DomesticPaymentConsentDetailsService extends PaymentConsentDetailsService<FRDomesticPaymentConsent> {
 
     private final PaymentConsentService paymentConsentService;
-    private final TppService tppService;
 
     public DomesticPaymentConsentDetailsService(PaymentConsentService paymentConsentService,
                                                 TppService tppService) {
+        super(paymentConsentService, tppService);
         this.paymentConsentService = paymentConsentService;
-        this.tppService = tppService;
     }
 
     @Override
-    public DomesticPaymentConsentDetails getConsentDetails(ConsentDetailsRequest request) throws OBErrorException {
-        String consentRequestJwt = request.getConsentRequestJwtString();
-        log.debug("Received a domestic payment consent request with JWT: '{}'", consentRequestJwt);
-        String consentId = request.getIntentId();
-        log.debug("=> The payment's consent id: '{}'", consentId);
-        String clientId = request.getClientId();
-        log.debug("=> The client id: '{}'", clientId);
+    protected FRDomesticPaymentConsent getPaymentConsent(String consentId) {
+        return paymentConsentService.getConsent(consentId, FRDomesticPaymentConsent.class);
+    }
 
-        FRDomesticPaymentConsent domesticConsent = paymentConsentService.getConsent(consentId, FRDomesticPaymentConsent.class);
-        if (domesticConsent == null) {
-            log.error("The PISP '{}' is referencing a domestic payment consent {} that doesn't exist", clientId, consentId);
-            throw new OBErrorException(PAYMENT_CONSENT_NOT_FOUND, clientId, consentId);
+    @Override
+    protected String getDebitAccountId(FRDomesticPaymentConsent paymentConsent) {
+        OBWriteDomestic2DataInitiation initiation = paymentConsent.getData().getInitiation();
+        if (initiation.getDebtorAccount() == null) {
+            return null;
         }
-        List<FRAccountWithBalance> accounts = request.getAccounts();
+        return initiation.getDebtorAccount().getIdentification();
+    }
 
-        // Only show the debtor account if specified in consent
-        OBWriteDomestic2DataInitiation initiation = domesticConsent.getData().getInitiation();
-        if (initiation.getDebtorAccount() != null) {
-            String identification = initiation.getDebtorAccount().getIdentification();
-            Optional<FRAccountWithBalance> matchingUserAccount = getMatchingAccount(identification, accounts);
-            if (matchingUserAccount.isEmpty()) {
-                log.error("The PISP '{}' created the payment request '{}' but the debtor account: {} on the payment " +
-                        "consent is not one of the user's accounts: {}.", domesticConsent.getOauth2ClientId(), consentId,
-                        initiation.getDebtorAccount(), accounts);
-                throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_DEBTOR_ACCOUNT_NOT_FOUND,
-                        clientId, consentId, accounts);
-            }
-            accounts = List.of(matchingUserAccount.get());
-        }
-
-        Optional<Tpp> isTpp = tppService.getTpp(domesticConsent.getOauth2ClientId());
-        if (isTpp.isEmpty()) {
-            log.error("The TPP '{}' (Client ID {}) that created this consent id '{}' doesn't exist anymore.",
-                    domesticConsent.getOauth2ClientId(), clientId, consentId);
-            throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_NOT_FOUND_TPP, clientId, consentId,
-                    emptyList());
-        }
-        Tpp tpp = isTpp.get();
-
-        // Verify the pisp is the same than the one that created this payment
-        verifyTppCreatedPaymentConsent(clientId, tpp.getClientId(), consentId);
-
-        // Associate the payment to this user
-        domesticConsent.setResourceOwnerUsername(request.getUsername());
-        paymentConsentService.updateConsent(domesticConsent);
-
+    @Override
+    protected ConsentDetails buildResponse(FRDomesticPaymentConsent paymentConsent,
+                                           List<FRAccountWithBalance> accounts,
+                                           Tpp tpp) {
+        OBWriteDomestic2DataInitiation initiation = paymentConsent.getData().getInitiation();
         return DomesticPaymentConsentDetails.builder()
                 .instructedAmount(toFRAmount(initiation.getInstructedAmount()))
                 .accounts(accounts)
-                .username(request.getUsername())
+                .username(paymentConsent.getResourceOwnerUsername())
+                .clientId(tpp.getClientId())
                 .logo(tpp.getLogoUri())
-                .merchantName(domesticConsent.getOauth2ClientName())
-                .clientId(clientId)
+                .merchantName(paymentConsent.getOauth2ClientName())
                 .paymentReference(Optional.ofNullable(
                         initiation.getRemittanceInformation())
                         .map(OBWriteDomestic2DataInitiationRemittanceInformation::getReference)

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticScheduledPaymentConsentDetailsService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticScheduledPaymentConsentDetailsService.java
@@ -17,12 +17,11 @@ package com.forgerock.securebanking.openbanking.uk.rcs.service.detail;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.tpp.Tpp;
-import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
+import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.ConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.DomesticScheduledPaymentConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.TppService;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRDomesticScheduledPaymentConsent;
-import com.forgerock.securebanking.openbanking.uk.rcs.exception.InvalidConsentException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationRemittanceInformation;
@@ -32,77 +31,44 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.FRAmountConverter.toFRAmount;
-import static com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType.*;
-import static com.forgerock.securebanking.openbanking.uk.rcs.util.AccountWithBalanceMatcher.getMatchingAccount;
-import static java.util.Collections.emptyList;
 
 @Service
 @Slf4j
-public class DomesticScheduledPaymentConsentDetailsService implements ConsentDetailsService {
+public class DomesticScheduledPaymentConsentDetailsService extends PaymentConsentDetailsService<FRDomesticScheduledPaymentConsent> {
 
     private final PaymentConsentService paymentConsentService;
-    private final TppService tppService;
 
-    public DomesticScheduledPaymentConsentDetailsService(PaymentConsentService paymentConsentService,
-                                                         TppService tppService) {
+    public DomesticScheduledPaymentConsentDetailsService(PaymentConsentService paymentConsentService, TppService tppService) {
+        super(paymentConsentService, tppService);
         this.paymentConsentService = paymentConsentService;
-        this.tppService = tppService;
     }
 
     @Override
-    public DomesticScheduledPaymentConsentDetails getConsentDetails(ConsentDetailsRequest request) throws OBErrorException {
-        String consentRequestJwt = request.getConsentRequestJwtString();
-        log.debug("Received a domestic scheduled payment consent request with JWT: '{}'", consentRequestJwt);
-        String consentId = request.getIntentId();
-        log.debug("=> The payment's consent id: '{}'", consentId);
-        String clientId = request.getClientId();
-        log.debug("=> The client id: '{}'", clientId);
+    protected FRDomesticScheduledPaymentConsent getPaymentConsent(String consentId) {
+        return paymentConsentService.getConsent(consentId, FRDomesticScheduledPaymentConsent.class);
+    }
 
-        FRDomesticScheduledPaymentConsent domesticConsent = paymentConsentService.getConsent(consentId, FRDomesticScheduledPaymentConsent.class);
-        if (domesticConsent == null) {
-            log.error("The PISP '{}' is referencing a domestic payment consent {} that doesn't exist", clientId, consentId);
-            throw new OBErrorException(PAYMENT_CONSENT_NOT_FOUND, clientId, consentId);
+    @Override
+    protected String getDebitAccountId(FRDomesticScheduledPaymentConsent paymentConsent) {
+        OBWriteDomesticScheduled2DataInitiation initiation = paymentConsent.getData().getInitiation();
+        if (initiation.getDebtorAccount() == null) {
+            return null;
         }
-        List<FRAccountWithBalance> accounts = request.getAccounts();
+        return initiation.getDebtorAccount().getIdentification();
+    }
 
-        // Only show the debtor account if specified in consent
-        OBWriteDomesticScheduled2DataInitiation initiation = domesticConsent.getData().getInitiation();
-        if (initiation.getDebtorAccount() != null) {
-            String identification = initiation.getDebtorAccount().getIdentification();
-            Optional<FRAccountWithBalance> matchingUserAccount = getMatchingAccount(identification, accounts);
-            if (matchingUserAccount.isEmpty()) {
-                log.error("The PISP '{}' created the payment request '{}' but the debtor account: {} on the payment " +
-                                "consent is not one of the user's accounts: {}.", domesticConsent.getOauth2ClientId(), consentId,
-                        initiation.getDebtorAccount(), accounts);
-                throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_DEBTOR_ACCOUNT_NOT_FOUND,
-                        clientId, consentId, accounts);
-            }
-            accounts = List.of(matchingUserAccount.get());
-        }
-
-        Optional<Tpp> isTpp = tppService.getTpp(domesticConsent.getOauth2ClientId());
-        if (isTpp.isEmpty()) {
-            log.error("The TPP '{}' (Client ID {}) that created this consent id '{}' doesn't exist anymore.",
-                    domesticConsent.getOauth2ClientId(), clientId, consentId);
-            throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_NOT_FOUND_TPP, clientId, consentId,
-                    emptyList());
-        }
-        Tpp tpp = isTpp.get();
-
-        // Verify the pisp is the same than the one that created this payment
-        verifyTppCreatedPaymentConsent(clientId, tpp.getClientId(), consentId);
-
-        // Associate the payment to this user
-        domesticConsent.setResourceOwnerUsername(request.getUsername());
-        paymentConsentService.updateConsent(domesticConsent);
-
+    @Override
+    protected ConsentDetails buildResponse(FRDomesticScheduledPaymentConsent paymentConsent,
+                                           List<FRAccountWithBalance> accounts,
+                                           Tpp tpp) {
+        OBWriteDomesticScheduled2DataInitiation initiation = paymentConsent.getData().getInitiation();
         return DomesticScheduledPaymentConsentDetails.builder()
                 .instructedAmount(toFRAmount(initiation.getInstructedAmount()))
                 .accounts(accounts)
-                .username(request.getUsername())
+                .username(paymentConsent.getResourceOwnerUsername())
+                .clientId(tpp.getClientId())
                 .logo(tpp.getLogoUri())
-                .merchantName(domesticConsent.getOauth2ClientName())
-                .clientId(clientId)
+                .merchantName(paymentConsent.getOauth2ClientName())
                 .paymentReference(Optional.ofNullable(
                         initiation.getRemittanceInformation())
                         .map(OBWriteDomestic2DataInitiationRemittanceInformation::getReference)

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticStandingOrderConsentDetailsService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticStandingOrderConsentDetailsService.java
@@ -18,12 +18,11 @@ package com.forgerock.securebanking.openbanking.uk.rcs.service.detail;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRStandingOrderData;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.tpp.Tpp;
-import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
+import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.ConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.DomesticStandingOrderConsentDetails;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.TppService;
 import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRDomesticStandingOrderConsent;
-import com.forgerock.securebanking.openbanking.uk.rcs.exception.InvalidConsentException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
@@ -33,73 +32,40 @@ import java.util.Optional;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.FRAccountIdentifierConverter.toFRAccountIdentifier;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.FRAmountConverter.toFRAmount;
-import static com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType.*;
-import static com.forgerock.securebanking.openbanking.uk.rcs.util.AccountWithBalanceMatcher.getMatchingAccount;
-import static java.util.Collections.emptyList;
 
 @Service
 @Slf4j
-public class DomesticStandingOrderConsentDetailsService implements ConsentDetailsService {
+public class DomesticStandingOrderConsentDetailsService extends PaymentConsentDetailsService<FRDomesticStandingOrderConsent> {
 
     private final PaymentConsentService paymentConsentService;
-    private final TppService tppService;
 
-    public DomesticStandingOrderConsentDetailsService(PaymentConsentService paymentConsentService,
-                                                         TppService tppService) {
+    public DomesticStandingOrderConsentDetailsService(PaymentConsentService paymentConsentService, TppService tppService) {
+        super(paymentConsentService, tppService);
         this.paymentConsentService = paymentConsentService;
-        this.tppService = tppService;
     }
 
     @Override
-    public DomesticStandingOrderConsentDetails getConsentDetails(ConsentDetailsRequest request) throws OBErrorException {
-        String consentRequestJwt = request.getConsentRequestJwtString();
-        log.debug("Received a domestic standing order consent request with JWT: '{}'", consentRequestJwt);
-        String consentId = request.getIntentId();
-        log.debug("=> The payment's consent id: '{}'", consentId);
-        String clientId = request.getClientId();
-        log.debug("=> The client id: '{}'", clientId);
+    protected FRDomesticStandingOrderConsent getPaymentConsent(String consentId) {
+        return paymentConsentService.getConsent(consentId, FRDomesticStandingOrderConsent.class);
+    }
 
-        FRDomesticStandingOrderConsent domesticConsent = paymentConsentService.getConsent(consentId, FRDomesticStandingOrderConsent.class);
-        if (domesticConsent == null) {
-            log.error("The PISP '{}' is referencing a domestic payment consent {} that doesn't exist", clientId, consentId);
-            throw new OBErrorException(PAYMENT_CONSENT_NOT_FOUND, clientId, consentId);
+    @Override
+    protected String getDebitAccountId(FRDomesticStandingOrderConsent paymentConsent) {
+        OBWriteDomesticStandingOrder3DataInitiation initiation = paymentConsent.getData().getInitiation();
+        if (initiation.getDebtorAccount() == null) {
+            return null;
         }
-        List<FRAccountWithBalance> accounts = request.getAccounts();
+        return initiation.getDebtorAccount().getIdentification();
+    }
 
-        // Only show the debtor account if specified in consent
-        OBWriteDomesticStandingOrder3DataInitiation initiation = domesticConsent.getData().getInitiation();
-        if (initiation.getDebtorAccount() != null) {
-            String identification = initiation.getDebtorAccount().getIdentification();
-            Optional<FRAccountWithBalance> matchingUserAccount = getMatchingAccount(identification, accounts);
-            if (matchingUserAccount.isEmpty()) {
-                log.error("The PISP '{}' created the payment request '{}' but the debtor account: {} on the payment " +
-                                "consent is not one of the user's accounts: {}.", domesticConsent.getOauth2ClientId(), consentId,
-                        initiation.getDebtorAccount(), accounts);
-                throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_DEBTOR_ACCOUNT_NOT_FOUND,
-                        clientId, consentId, accounts);
-            }
-            accounts = List.of(matchingUserAccount.get());
-        }
-
-        Optional<Tpp> isTpp = tppService.getTpp(domesticConsent.getOauth2ClientId());
-        if (isTpp.isEmpty()) {
-            log.error("The TPP '{}' (Client ID {}) that created this consent id '{}' doesn't exist anymore.",
-                    domesticConsent.getOauth2ClientId(), clientId, consentId);
-            throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_NOT_FOUND_TPP, clientId, consentId,
-                    emptyList());
-        }
-        Tpp tpp = isTpp.get();
-
-        // Verify the pisp is the same than the one that created this payment
-        verifyTppCreatedPaymentConsent(clientId, tpp.getClientId(), consentId);
-
-        // Associate the payment to this user
-        domesticConsent.setResourceOwnerUsername(request.getUsername());
-        paymentConsentService.updateConsent(domesticConsent);
-
+    @Override
+    protected ConsentDetails buildResponse(FRDomesticStandingOrderConsent paymentConsent,
+                                           List<FRAccountWithBalance> accounts,
+                                           Tpp tpp) {
+        OBWriteDomesticStandingOrder3DataInitiation initiation = paymentConsent.getData().getInitiation();
         FRStandingOrderData standingOrderData = FRStandingOrderData.builder()
-                .accountId(domesticConsent.getAccountId())
-                .standingOrderId(domesticConsent.getId())
+                .accountId(paymentConsent.getAccountId())
+                .standingOrderId(paymentConsent.getId())
                 .finalPaymentAmount(toFRAmount(initiation.getFinalPaymentAmount()))
                 .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
                 .firstPaymentAmount(toFRAmount(initiation.getFirstPaymentAmount()))
@@ -113,10 +79,10 @@ public class DomesticStandingOrderConsentDetailsService implements ConsentDetail
         return DomesticStandingOrderConsentDetails.builder()
                 .standingOrder(standingOrderData)
                 .accounts(accounts)
-                .username(request.getUsername())
+                .username(paymentConsent.getResourceOwnerUsername())
+                .clientId(tpp.getClientId())
                 .logo(tpp.getLogoUri())
-                .merchantName(domesticConsent.getOauth2ClientName())
-                .clientId(clientId)
+                .merchantName(paymentConsent.getOauth2ClientName())
                 .paymentReference(Optional.ofNullable(initiation.getReference()).orElse(""))
                 .build();
     }

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/PaymentConsentDetailsService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/PaymentConsentDetailsService.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.detail;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.tpp.Tpp;
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
+import com.forgerock.securebanking.openbanking.uk.rcs.api.dto.consent.details.ConsentDetails;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.TppService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRPaymentConsent;
+import com.forgerock.securebanking.openbanking.uk.rcs.exception.InvalidConsentException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType.*;
+import static com.forgerock.securebanking.openbanking.uk.rcs.util.AccountWithBalanceMatcher.getMatchingAccount;
+import static java.util.Collections.emptyList;
+
+/**
+ * Abstract class providing common functionality for retrieving the details of a consent for each payment type.
+ *
+ * @param <CONSENT> The type of the {@link FRPaymentConsent} that overriding classes are dealing with.
+ */
+@Slf4j
+public abstract class PaymentConsentDetailsService<CONSENT extends FRPaymentConsent> implements ConsentDetailsService {
+
+    private final PaymentConsentService paymentConsentService;
+    private final TppService tppService;
+
+    public PaymentConsentDetailsService(PaymentConsentService paymentConsentService, TppService tppService) {
+        this.paymentConsentService = paymentConsentService;
+        this.tppService = tppService;
+    }
+
+    @Override
+    public ConsentDetails getConsentDetails(ConsentDetailsRequest request) throws OBErrorException {
+        String consentRequestJwt = request.getConsentRequestJwtString();
+        log.debug("Received a payment consent request with JWT: '{}'", consentRequestJwt);
+        String consentId = request.getIntentId();
+        log.debug("=> The payment's consent id: '{}'", consentId);
+        String clientId = request.getClientId();
+        log.debug("=> The client id: '{}'", clientId);
+
+        CONSENT paymentConsent = getPaymentConsent(consentId);
+        if (paymentConsent == null) {
+            log.error("The PISP '{}' is referencing a payment payment consent {} that doesn't exist", clientId, consentId);
+            throw new OBErrorException(PAYMENT_CONSENT_NOT_FOUND, clientId, consentId);
+        }
+        List<FRAccountWithBalance> accounts = request.getAccounts();
+
+        // Only show the debtor account if specified in consent
+        String debtorAccountId = getDebitAccountId(paymentConsent);
+        if (debtorAccountId != null) {
+            Optional<FRAccountWithBalance> matchingUserAccount = getMatchingAccount(debtorAccountId, accounts);
+            if (matchingUserAccount.isEmpty()) {
+                log.error("The PISP '{}' created the payment request '{}' but the debtor account: {} on the payment " +
+                                "consent is not one of the user's accounts: {}.", paymentConsent.getOauth2ClientId(), consentId,
+                        debtorAccountId, accounts);
+                throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_DEBTOR_ACCOUNT_NOT_FOUND,
+                        clientId, consentId, accounts);
+            }
+            accounts = List.of(matchingUserAccount.get());
+        }
+
+        Optional<Tpp> isTpp = tppService.getTpp(paymentConsent.getOauth2ClientId());
+        if (isTpp.isEmpty()) {
+            log.error("The TPP '{}' (Client ID {}) that created this consent id '{}' doesn't exist anymore.",
+                    paymentConsent.getOauth2ClientId(), clientId, consentId);
+            throw new InvalidConsentException(consentRequestJwt, RCS_CONSENT_REQUEST_NOT_FOUND_TPP, clientId, consentId,
+                    emptyList());
+        }
+        Tpp tpp = isTpp.get();
+
+        // Verify the pisp is the same than the one that created this payment
+        verifyTppCreatedPaymentConsent(clientId, tpp.getClientId(), consentId);
+
+        // Associate the payment to this user
+        paymentConsent.setResourceOwnerUsername(request.getUsername());
+        paymentConsentService.updateConsent(paymentConsent);
+
+        return buildResponse(paymentConsent, accounts, tpp);
+    }
+
+    /**
+     * Overriding classes need to retrieve their own type of {@link FRPaymentConsent}.
+     *
+     * @param consentId The ID of the {@link FRPaymentConsent} in question.
+     * @return The corresponding {@link FRPaymentConsent} (should never be null).
+     */
+    protected abstract CONSENT getPaymentConsent(String consentId);
+
+    /**
+     * Overriding classes know which underlying OB "DataInitiation" object they're dealing with, so know how to
+     * retrieve the debit account's identifier (e.g. concatenated sort code and account number).
+     *
+     * @param paymentConsent The {@link FRPaymentConsent} containing the payment related data.
+     * @return The ID of the debit account, or null if it hasn't been provided in the consent data.
+     */
+    protected abstract String getDebitAccountId(CONSENT paymentConsent);
+
+    /**
+     * Overriding classes need to build the specific {@link ConsentDetails} for the payment in question.
+     *
+     * @param paymentConsent The {@link FRPaymentConsent} containing the payment related data.
+     * @param accounts The list of user's accounts.
+     * @param tpp The {@link Tpp} associated with the consent.
+     * @return The specific {@link ConsentDetails} for the payment in question.
+     */
+    protected abstract ConsentDetails buildResponse(CONSENT paymentConsent,
+                                                    List<FRAccountWithBalance> accounts,
+                                                    Tpp tpp);
+}

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticPaymentConsentDetailsServiceTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticPaymentConsentDetailsServiceTest.java
@@ -78,7 +78,7 @@ public class DomesticPaymentConsentDetailsServiceTest {
         given(tppService.getTpp(consent.getOauth2ClientId())).willReturn(Optional.of(tpp));
 
         // When
-        DomesticPaymentConsentDetails consentDetails = consentDetailsService.getConsentDetails(request);
+        DomesticPaymentConsentDetails consentDetails = (DomesticPaymentConsentDetails) consentDetailsService.getConsentDetails(request);
 
         // Then
         assertThat(consentDetails).isNotNull();

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticScheduledPaymentConsentDetailsServiceTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticScheduledPaymentConsentDetailsServiceTest.java
@@ -77,7 +77,7 @@ public class DomesticScheduledPaymentConsentDetailsServiceTest {
         given(tppService.getTpp(consent.getOauth2ClientId())).willReturn(Optional.of(tpp));
 
         // When
-        DomesticScheduledPaymentConsentDetails consentDetails = consentDetailsService.getConsentDetails(request);
+        DomesticScheduledPaymentConsentDetails consentDetails = (DomesticScheduledPaymentConsentDetails) consentDetailsService.getConsentDetails(request);
 
         // Then
         assertThat(consentDetails).isNotNull();

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticStandingOrderConsentDetailsServiceTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/DomesticStandingOrderConsentDetailsServiceTest.java
@@ -76,7 +76,7 @@ public class DomesticStandingOrderConsentDetailsServiceTest {
         given(tppService.getTpp(consent.getOauth2ClientId())).willReturn(Optional.of(tpp));
 
         // When
-        DomesticStandingOrderConsentDetails consentDetails = consentDetailsService.getConsentDetails(request);
+        DomesticStandingOrderConsentDetails consentDetails = (DomesticStandingOrderConsentDetails) consentDetailsService.getConsentDetails(request);
 
         // Then
         assertThat(consentDetails).isNotNull();


### PR DESCRIPTION
### Tidy up of the payment related ConsentDetailsService classes

- Reduced duplication so that there's only one implementation of `getPaymentConsent()`.

**Issue**: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/66