### PR TITLE
66: Submission of international payment consents

### DIFF
--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/idm/dto/consent/FRPaymentConsent.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/client/idm/dto/consent/FRPaymentConsent.java
@@ -24,7 +24,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         property = "type"
 )
 @JsonSubTypes({
-        @Type(value = FRDomesticPaymentConsent.class, name = "FRDomesticPaymentConsent")
+        @Type(value = FRDomesticPaymentConsent.class, name = "FRDomesticPaymentConsent"),
+        @Type(value = FRDomesticScheduledPaymentConsent.class, name = "FRDomesticScheduledPaymentConsent"),
+        @Type(value = FRDomesticStandingOrderConsent.class, name = "FRDomesticStandingOrderConsent"),
+        @Type(value = FRInternationalPaymentConsent.class, name = "FRInternationalPaymentConsent"),
+        @Type(value = FRInternationalScheduledPaymentConsent.class, name = "FRInternationalScheduledPaymentConsent"),
+        @Type(value = FRInternationalStandingOrderConsent.class, name = "FRInternationalStandingOrderConsent"),
+        @Type(value = FRFilePaymentConsent.class, name = "FRFilePaymentConsent"),
+        @Type(value = FRFundsConfirmationConsent.class, name = "FRFundsConfirmationConsent")
 })
 public interface FRPaymentConsent {
 

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/ConsentDecisionServiceDelegate.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/ConsentDecisionServiceDelegate.java
@@ -30,16 +30,31 @@ public class ConsentDecisionServiceDelegate {
     private final DomesticPaymentConsentDecisionService domesticPaymentConsentDecisionService;
     private final DomesticScheduledPaymentConsentDecisionService domesticScheduledPaymentConsentDecisionService;
     private final DomesticStandingOrderConsentDecisionService domesticStandingOrderConsentDecisionService;
+    private final InternationalPaymentConsentDecisionService internationalPaymentConsentDecisionService;
+    private final InternationalScheduledPaymentConsentDecisionService internationalScheduledPaymentConsentDecisionService;
+    private final InternationalStandingOrderConsentDecisionService internationalStandingOrderConsentDecisionService;
+    private final FilePaymentConsentDecisionService filePaymentConsentDecisionService;
+    private final FundsConfirmationConsentDecisionService fundsConfirmationConsentDecisionService;
 
     public ConsentDecisionServiceDelegate(
             AccountAccessConsentDecisionService accountAccessConsentDecisionService,
             DomesticPaymentConsentDecisionService domesticPaymentConsentDecisionService,
             DomesticScheduledPaymentConsentDecisionService domesticScheduledPaymentConsentDecisionService,
-            DomesticStandingOrderConsentDecisionService domesticStandingOrderConsentDecisionService) {
+            DomesticStandingOrderConsentDecisionService domesticStandingOrderConsentDecisionService,
+            InternationalPaymentConsentDecisionService internationalPaymentConsentDecisionService,
+            InternationalScheduledPaymentConsentDecisionService internationalScheduledPaymentConsentDecisionService,
+            InternationalStandingOrderConsentDecisionService internationalStandingOrderConsentDecisionService,
+            FilePaymentConsentDecisionService filePaymentConsentDecisionService,
+            FundsConfirmationConsentDecisionService fundsConfirmationConsentDecisionService) {
         this.accountAccessConsentDecisionService = accountAccessConsentDecisionService;
         this.domesticPaymentConsentDecisionService = domesticPaymentConsentDecisionService;
         this.domesticScheduledPaymentConsentDecisionService = domesticScheduledPaymentConsentDecisionService;
         this.domesticStandingOrderConsentDecisionService = domesticStandingOrderConsentDecisionService;
+        this.internationalPaymentConsentDecisionService = internationalPaymentConsentDecisionService;
+        this.internationalScheduledPaymentConsentDecisionService = internationalScheduledPaymentConsentDecisionService;
+        this.internationalStandingOrderConsentDecisionService = internationalStandingOrderConsentDecisionService;
+        this.filePaymentConsentDecisionService = filePaymentConsentDecisionService;
+        this.fundsConfirmationConsentDecisionService = fundsConfirmationConsentDecisionService;
     }
 
     public ConsentDecisionService getConsentDecisionService(String intentId) throws OBErrorException {
@@ -58,6 +73,16 @@ public class ConsentDecisionServiceDelegate {
                 return domesticScheduledPaymentConsentDecisionService;
             case PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT:
                 return domesticStandingOrderConsentDecisionService;
+            case PAYMENT_INTERNATIONAL_CONSENT :
+                return internationalPaymentConsentDecisionService;
+            case PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT:
+                return internationalScheduledPaymentConsentDecisionService;
+            case PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT:
+                return internationalStandingOrderConsentDecisionService;
+            case PAYMENT_FILE_CONSENT:
+                return filePaymentConsentDecisionService;
+            case FUNDS_CONFIRMATION_CONSENT:
+                return fundsConfirmationConsentDecisionService;
             default :
                 log.error("Unsupported intent ID '{}'", intentId);
                 throw new OBErrorException(RCS_CONSENT_REQUEST_INVALID, "Unsupported intent ID: '" + intentId + "'");

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/FilePaymentConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/FilePaymentConsentDecisionService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.decision;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRFilePaymentConsent;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FilePaymentConsentDecisionService extends PaymentConsentDecisionService {
+
+    public FilePaymentConsentDecisionService(PaymentConsentService paymentConsentService,
+                                             ObjectMapper objectMapper,
+                                             PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRFilePaymentConsent> getConsentClass() {
+        return FRFilePaymentConsent.class;
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/FundsConfirmationConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/FundsConfirmationConsentDecisionService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.decision;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRFundsConfirmationConsent;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FundsConfirmationConsentDecisionService extends PaymentConsentDecisionService {
+
+    public FundsConfirmationConsentDecisionService(PaymentConsentService paymentConsentService,
+                                                   ObjectMapper objectMapper,
+                                                   PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRFundsConfirmationConsent> getConsentClass() {
+        return FRFundsConfirmationConsent.class;
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalPaymentConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalPaymentConsentDecisionService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.decision;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRInternationalPaymentConsent;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InternationalPaymentConsentDecisionService extends PaymentConsentDecisionService {
+
+    public InternationalPaymentConsentDecisionService(PaymentConsentService paymentConsentService,
+                                                      ObjectMapper objectMapper,
+                                                      PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRInternationalPaymentConsent> getConsentClass() {
+        return FRInternationalPaymentConsent.class;
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalScheduledPaymentConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalScheduledPaymentConsentDecisionService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.decision;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRInternationalScheduledPaymentConsent;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InternationalScheduledPaymentConsentDecisionService extends PaymentConsentDecisionService {
+
+    public InternationalScheduledPaymentConsentDecisionService(PaymentConsentService paymentConsentService,
+                                                               ObjectMapper objectMapper,
+                                                               PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRInternationalScheduledPaymentConsent> getConsentClass() {
+        return FRInternationalScheduledPaymentConsent.class;
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalStandingOrderConsentDecisionService.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalStandingOrderConsentDecisionService.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.decision;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRInternationalStandingOrderConsent;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InternationalStandingOrderConsentDecisionService extends PaymentConsentDecisionService {
+
+    public InternationalStandingOrderConsentDecisionService(PaymentConsentService paymentConsentService,
+                                                            ObjectMapper objectMapper,
+                                                            PaymentConsentDecisionUpdater paymentConsentDecisionUpdater) {
+        super(paymentConsentService, objectMapper, paymentConsentDecisionUpdater);
+    }
+
+    @Override
+    protected Class<FRInternationalStandingOrderConsent> getConsentClass() {
+        return FRInternationalStandingOrderConsent.class;
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/ConsentDetailsServiceDelegate.java
+++ b/securebanking-openbanking-uk-rcs-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/ConsentDetailsServiceDelegate.java
@@ -31,32 +31,31 @@ public class ConsentDetailsServiceDelegate {
     private final DomesticPaymentConsentDetailsService domesticPaymentConsentDetailsService;
     private final DomesticScheduledPaymentConsentDetailsService domesticScheduledPaymentConsentDetailsService;
     private final DomesticStandingOrderConsentDetailsService domesticStandingOrderConsentDetailsService;
-    // TODO #66 - add other consent types
-//    private final InternationalPaymentConsentDetailsService internationalPaymentConsentDetailsService;
-//    private final InternationalScheduledPaymentConsentDetailsService internationalScheduledPaymentConsentDetailsService;
-//    private final InternationalStandingOrderConsentDetailsService internationalStandingOrderConsentDetailsService;
-//    private final FilePaymentConsentDetailsService filePaymentConsentDetailsService;
-//    private final FundsConfirmationConsentDetailsService fundsConfirmationConsentDetailsService;
+    private final InternationalPaymentConsentDetailsService internationalPaymentConsentDetailsService;
+    private final InternationalScheduledPaymentConsentDetailsService internationalScheduledPaymentConsentDetailsService;
+    private final InternationalStandingOrderConsentDetailsService internationalStandingOrderConsentDetailsService;
+    private final FilePaymentConsentDetailsService filePaymentConsentDetailsService;
+    private final FundsConfirmationConsentDetailsService fundsConfirmationConsentDetailsService;
 
     public ConsentDetailsServiceDelegate(
             AccountConsentDetailsService accountConsentDetailsService,
             DomesticPaymentConsentDetailsService domesticPaymentConsentDetailsService,
             DomesticScheduledPaymentConsentDetailsService domesticScheduledPaymentConsentDetailsService,
-            DomesticStandingOrderConsentDetailsService domesticStandingOrderConsentDetailsService) {
-//            InternationalPaymentConsentDetailsService internationalPaymentConsentDetailsService,
-//            InternationalScheduledPaymentConsentDetailsService internationalScheduledPaymentConsentDetailsService,
-//            InternationalStandingOrderConsentDetailsService internationalStandingOrderConsentDetailsService,
-//            FilePaymentConsentDetailsService filePaymentConsentDetailsService,
-//            FundsConfirmationConsentDetailsService fundsConfirmationConsentDetailsService) {
+            DomesticStandingOrderConsentDetailsService domesticStandingOrderConsentDetailsService,
+            InternationalPaymentConsentDetailsService internationalPaymentConsentDetailsService,
+            InternationalScheduledPaymentConsentDetailsService internationalScheduledPaymentConsentDetailsService,
+            InternationalStandingOrderConsentDetailsService internationalStandingOrderConsentDetailsService,
+            FilePaymentConsentDetailsService filePaymentConsentDetailsService,
+            FundsConfirmationConsentDetailsService fundsConfirmationConsentDetailsService) {
         this.accountConsentDetailsService = accountConsentDetailsService;
         this.domesticPaymentConsentDetailsService = domesticPaymentConsentDetailsService;
         this.domesticScheduledPaymentConsentDetailsService = domesticScheduledPaymentConsentDetailsService;
         this.domesticStandingOrderConsentDetailsService = domesticStandingOrderConsentDetailsService;
-//        this.internationalPaymentConsentDetailsService = internationalPaymentConsentDetailsService;
-//        this.internationalScheduledPaymentConsentDetailsService = internationalScheduledPaymentConsentDetailsService;
-//        this.internationalStandingOrderConsentDetailsService = internationalStandingOrderConsentDetailsService;
-//        this.filePaymentConsentDetailsService = filePaymentConsentDetailsService;
-//        this.fundsConfirmationConsentDetailsService = fundsConfirmationConsentDetailsService;
+        this.internationalPaymentConsentDetailsService = internationalPaymentConsentDetailsService;
+        this.internationalScheduledPaymentConsentDetailsService = internationalScheduledPaymentConsentDetailsService;
+        this.internationalStandingOrderConsentDetailsService = internationalStandingOrderConsentDetailsService;
+        this.filePaymentConsentDetailsService = filePaymentConsentDetailsService;
+        this.fundsConfirmationConsentDetailsService = fundsConfirmationConsentDetailsService;
     }
 
     public ConsentDetails getConsentDetails(ConsentDetailsRequest request) throws OBErrorException {
@@ -71,16 +70,16 @@ public class ConsentDetailsServiceDelegate {
                 return domesticScheduledPaymentConsentDetailsService.getConsentDetails(request);
             case PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT:
                 return domesticStandingOrderConsentDetailsService.getConsentDetails(request);
-//            case PAYMENT_INTERNATIONAL_CONSENT:
-//                return internationalPaymentConsentDetailsService.getConsentDetails(request);
-//            case PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT:
-//                return internationalScheduledPaymentConsentDetailsService.getConsentDetails(request);
-//            case PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT:
-//                return internationalStandingOrderConsentDetailsService.getConsentDetails(request);
-//            case PAYMENT_FILE_CONSENT:
-//                return filePaymentConsentDetailsService.getConsentDetails(request);
-//            case FUNDS_CONFIRMATION_CONSENT:
-//                return fundsConfirmationConsentDetailsService.getConsentDetails(request);
+            case PAYMENT_INTERNATIONAL_CONSENT:
+                return internationalPaymentConsentDetailsService.getConsentDetails(request);
+            case PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT:
+                return internationalScheduledPaymentConsentDetailsService.getConsentDetails(request);
+            case PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT:
+                return internationalStandingOrderConsentDetailsService.getConsentDetails(request);
+            case PAYMENT_FILE_CONSENT:
+                return filePaymentConsentDetailsService.getConsentDetails(request);
+            case FUNDS_CONFIRMATION_CONSENT:
+                return fundsConfirmationConsentDetailsService.getConsentDetails(request);
             default:
                 log.error("Invalid intent ID: '{}'", intentId);
                 throw new OBErrorException(RCS_CONSENT_REQUEST_INVALID, "Invalid intent ID: '" + intentId + "'");

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/ConsentDecisionServiceDelegateTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/ConsentDecisionServiceDelegateTest.java
@@ -39,6 +39,17 @@ public class ConsentDecisionServiceDelegateTest {
     private DomesticScheduledPaymentConsentDecisionService domesticScheduledPaymentConsentDecisionService;
     @Mock
     private DomesticStandingOrderConsentDecisionService domesticStandingOrderConsentDecisionService;
+    @Mock
+    private InternationalPaymentConsentDecisionService internationalPaymentConsentDecisionService;
+    @Mock
+    private InternationalScheduledPaymentConsentDecisionService internationalScheduledPaymentConsentDecisionService;
+    @Mock
+    private InternationalStandingOrderConsentDecisionService internationalStandingOrderConsentDecisionService;
+    @Mock
+    private FilePaymentConsentDecisionService filePaymentConsentDecisionService;
+    @Mock
+    private FundsConfirmationConsentDecisionService fundsConfirmationConsentDecisionService;
+
     @InjectMocks
     private ConsentDecisionServiceDelegate delegate;
 
@@ -92,6 +103,71 @@ public class ConsentDecisionServiceDelegateTest {
         // Then
         assertThat(consentDecisionService).isNotNull();
         assertThat(consentDecisionService).isEqualTo(domesticStandingOrderConsentDecisionService);
+    }
+
+    @Test
+    public void shouldGetInternationalPaymentConsentDecisionService() throws OBErrorException {
+        // Given
+        String intentId = "PIC_1234";
+
+        // When
+        ConsentDecisionService consentDecisionService = delegate.getConsentDecisionService(intentId);
+
+        // Then
+        assertThat(consentDecisionService).isNotNull();
+        assertThat(consentDecisionService).isEqualTo(internationalPaymentConsentDecisionService);
+    }
+
+    @Test
+    public void shouldGetInternationalScheduledPaymentConsentDecisionService() throws OBErrorException {
+        // Given
+        String intentId = "PISC_1234";
+
+        // When
+        ConsentDecisionService consentDecisionService = delegate.getConsentDecisionService(intentId);
+
+        // Then
+        assertThat(consentDecisionService).isNotNull();
+        assertThat(consentDecisionService).isEqualTo(internationalScheduledPaymentConsentDecisionService);
+    }
+
+    @Test
+    public void shouldGetInternationalStandingOrderConsentDecisionService() throws OBErrorException {
+        // Given
+        String intentId = "PISOC_1234";
+
+        // When
+        ConsentDecisionService consentDecisionService = delegate.getConsentDecisionService(intentId);
+
+        // Then
+        assertThat(consentDecisionService).isNotNull();
+        assertThat(consentDecisionService).isEqualTo(internationalStandingOrderConsentDecisionService);
+    }
+
+    @Test
+    public void shouldGetFilePaymentConsentDecisionService() throws OBErrorException {
+        // Given
+        String intentId = "PFC_1234";
+
+        // When
+        ConsentDecisionService consentDecisionService = delegate.getConsentDecisionService(intentId);
+
+        // Then
+        assertThat(consentDecisionService).isNotNull();
+        assertThat(consentDecisionService).isEqualTo(filePaymentConsentDecisionService);
+    }
+
+    @Test
+    public void shouldGetFundsConfirmationConsentDecisionService() throws OBErrorException {
+        // Given
+        String intentId = "FCC_1234";
+
+        // When
+        ConsentDecisionService consentDecisionService = delegate.getConsentDecisionService(intentId);
+
+        // Then
+        assertThat(consentDecisionService).isNotNull();
+        assertThat(consentDecisionService).isEqualTo(fundsConfirmationConsentDecisionService);
     }
 
     @Test

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalPaymentConsentDecisionServiceTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/decision/InternationalPaymentConsentDecisionServiceTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.service.decision;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.PaymentConsentService;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRInternationalPaymentConsent;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType.PAYMENT_CONSENT_NOT_FOUND;
+import static com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent.FRInternationalPaymentConsentTestDataFactory.aValidFRInternationalPaymentConsent;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit test for {@link InternationalPaymentConsentDecisionService}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class InternationalPaymentConsentDecisionServiceTest {
+
+    @Mock
+    private PaymentConsentService paymentConsentService;
+    @Mock
+    private PaymentConsentDecisionUpdater consentDecisionUpdater;
+    private InternationalPaymentConsentDecisionService consentDecisionService;
+
+    @BeforeEach
+    public void setup() {
+        consentDecisionService = new InternationalPaymentConsentDecisionService(paymentConsentService,
+                new ObjectMapper(), consentDecisionUpdater);
+    }
+
+    @Test
+    public void shouldApproveConsent() throws OBErrorException {
+        // Given
+        String intentId = "PIC_1234";
+        FRInternationalPaymentConsent paymentConsent = aValidFRInternationalPaymentConsent();
+        given(paymentConsentService.getConsent(intentId, FRInternationalPaymentConsent.class)).willReturn(paymentConsent);
+
+        // When
+        consentDecisionService.processConsentDecision(intentId, consentDecisionSerialized("123456"), true);
+
+        // Then
+        verify(consentDecisionUpdater).applyUpdate(anyString(), anyString(), anyBoolean(), any(), any());
+    }
+
+    @Test
+    public void shouldFailToApproveConsentGivenConsentNotFound() {
+        // Given
+        String intentId = "PIC_1234";
+        FRInternationalPaymentConsent paymentConsent = aValidFRInternationalPaymentConsent();
+        given(paymentConsentService.getConsent(intentId, FRInternationalPaymentConsent.class)).willReturn(null);
+
+        // When
+        OBErrorException e = catchThrowableOfType(() ->
+                consentDecisionService.processConsentDecision(intentId,
+                        consentDecisionSerialized("2222"), true), OBErrorException.class);
+
+        // Then
+        Assertions.assertThat(e.getObriErrorType()).isEqualTo(PAYMENT_CONSENT_NOT_FOUND);
+    }
+
+    private String consentDecisionSerialized(String accountId) {
+        String consentDecisionSerialised = "{" +
+                "\"consentJwt\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva" +
+                "G4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"," +
+                "\"decision\":\"true\"," +
+                "\"accountId\":\"" + accountId + "\"}";
+        return consentDecisionSerialised;
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/ConsentDetailsServiceDelegateTest.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/service/detail/ConsentDetailsServiceDelegateTest.java
@@ -44,6 +44,16 @@ public class ConsentDetailsServiceDelegateTest {
     private DomesticScheduledPaymentConsentDetailsService domesticScheduledPaymentConsentDetailsService;
     @Mock
     private DomesticStandingOrderConsentDetailsService domesticStandingOrderConsentDetailsService;
+    @Mock
+    private InternationalPaymentConsentDetailsService internationalPaymentConsentDetailsService;
+    @Mock
+    private InternationalScheduledPaymentConsentDetailsService internationalScheduledPaymentConsentDetailsService;
+    @Mock
+    private InternationalStandingOrderConsentDetailsService internationalStandingOrderConsentDetailsService;
+    @Mock
+    private FilePaymentConsentDetailsService filePaymentConsentDetailsService;
+    @Mock
+    private FundsConfirmationConsentDetailsService fundsConfirmationConsentDetailsService;
     @InjectMocks
     private ConsentDetailsServiceDelegate consentDetailsServiceDelegate;
 
@@ -108,7 +118,82 @@ public class ConsentDetailsServiceDelegateTest {
     }
 
     @Test
-    public void shouldFailToGetConsentDetailsGivenUnsupportedIntentType() throws OBErrorException {
+    public void shouldGetInternationalPaymentConsentDetails() throws OBErrorException {
+        // Given
+        ConsentDetailsRequest request = aValidInternationalPaymentConsentDetailsRequestBuilder().build();
+        InternationalPaymentConsentDetails paymentConsentDetails = InternationalPaymentConsentDetails.builder().build();
+        given(internationalPaymentConsentDetailsService.getConsentDetails(request)).willReturn(paymentConsentDetails);
+
+        // When
+        ConsentDetails consentDetails = consentDetailsServiceDelegate.getConsentDetails(request);
+
+        // Then
+        assertThat(consentDetails).isNotNull();
+        verify(internationalPaymentConsentDetailsService).getConsentDetails(request);
+    }
+
+    @Test
+    public void shouldGetInternationalScheduledPaymentConsentDetails() throws OBErrorException {
+        // Given
+        ConsentDetailsRequest request = aValidInternationalScheduledPaymentConsentDetailsRequestBuilder().build();
+        InternationalScheduledPaymentConsentDetails paymentConsentDetails = InternationalScheduledPaymentConsentDetails.builder().build();
+        given(internationalScheduledPaymentConsentDetailsService.getConsentDetails(request)).willReturn(paymentConsentDetails);
+
+        // When
+        ConsentDetails consentDetails = consentDetailsServiceDelegate.getConsentDetails(request);
+
+        // Then
+        assertThat(consentDetails).isNotNull();
+        verify(internationalScheduledPaymentConsentDetailsService).getConsentDetails(request);
+    }
+
+    @Test
+    public void shouldGetInternationalStandingOrderConsentDetails() throws OBErrorException {
+        // Given
+        ConsentDetailsRequest request = aValidInternationalStandingOrderConsentDetailsRequestBuilder().build();
+        InternationalStandingOrderConsentDetails paymentConsentDetails = InternationalStandingOrderConsentDetails.builder().build();
+        given(internationalStandingOrderConsentDetailsService.getConsentDetails(request)).willReturn(paymentConsentDetails);
+
+        // When
+        ConsentDetails consentDetails = consentDetailsServiceDelegate.getConsentDetails(request);
+
+        // Then
+        assertThat(consentDetails).isNotNull();
+        verify(internationalStandingOrderConsentDetailsService).getConsentDetails(request);
+    }
+
+    @Test
+    public void shouldGetFilePaymentConsentDetails() throws OBErrorException {
+        // Given
+        ConsentDetailsRequest request = aValidFilePaymentConsentDetailsRequestBuilder().build();
+        FilePaymentConsentDetails paymentConsentDetails = FilePaymentConsentDetails.builder().build();
+        given(filePaymentConsentDetailsService.getConsentDetails(request)).willReturn(paymentConsentDetails);
+
+        // When
+        ConsentDetails consentDetails = consentDetailsServiceDelegate.getConsentDetails(request);
+
+        // Then
+        assertThat(consentDetails).isNotNull();
+        verify(filePaymentConsentDetailsService).getConsentDetails(request);
+    }
+
+    @Test
+    public void shouldGetFundsConfirmationConsentDetails() throws OBErrorException {
+        // Given
+        ConsentDetailsRequest request = aValidFundsConfirmationConsentDetailsRequestBuilder().build();
+        FundsConfirmationConsentDetails paymentConsentDetails = FundsConfirmationConsentDetails.builder().build();
+        given(fundsConfirmationConsentDetailsService.getConsentDetails(request)).willReturn(paymentConsentDetails);
+
+        // When
+        ConsentDetails consentDetails = consentDetailsServiceDelegate.getConsentDetails(request);
+
+        // Then
+        assertThat(consentDetails).isNotNull();
+        verify(fundsConfirmationConsentDetailsService).getConsentDetails(request);
+    }
+
+    @Test
+    public void shouldFailToGetConsentDetailsGivenUnsupportedIntentType() {
         // Given
         ConsentDetailsRequest request = aValidAccountAccessConsentDetailsRequestBuilder()
                 .intentId("AR_" + randomUUID().toString())

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/ConsentDetailsRequestTestDataFactory.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/ConsentDetailsRequestTestDataFactory.java
@@ -65,6 +65,14 @@ public class ConsentDetailsRequestTestDataFactory {
         return getConsentDetailsRequestBuilder("PISOC_");
     }
 
+    public static ConsentDetailsRequest.ConsentDetailsRequestBuilder aValidFilePaymentConsentDetailsRequestBuilder() {
+        return getConsentDetailsRequestBuilder("PFC_");
+    }
+
+    public static ConsentDetailsRequest.ConsentDetailsRequestBuilder aValidFundsConfirmationConsentDetailsRequestBuilder() {
+        return getConsentDetailsRequestBuilder("FCC_");
+    }
+
     private static ConsentDetailsRequest.ConsentDetailsRequestBuilder getConsentDetailsRequestBuilder(String intentType) {
         try {
             return ConsentDetailsRequest.builder()

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/JwtHelper.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/JwtHelper.java
@@ -29,7 +29,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 public class JwtHelper {
 
     /**
-     * Creates a JWT that mimics the value that's sent from the UI when the user grants consent.
+     * Creates a JWT that mimics the value that's sent from the UI when requesting a consent's details, or when the
+     * user grants consent.
      *
      * @param amPath The path to the WireMock instance, simulating AM. This is used for the `consentApprovalRedirectUri`.
      * @param serverPort The dynamic port that WireMock is running on.
@@ -39,7 +40,7 @@ public class JwtHelper {
      * @return A {@link String} representation of the consent decision JWT.
      */
     @SneakyThrows
-    public static String consentDecisionJwt(String amPath, int serverPort, String clientId, String intentId, String username) {
+    public static String consentRequestJwt(String amPath, int serverPort, String clientId, String intentId, String username) {
         String amUri = "http://localhost:" + serverPort + amPath;
         String payload = "{\n" +
                 "\"clientId\":\"" + clientId + "\"," +

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/WireMockStubHelper.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/WireMockStubHelper.java
@@ -18,7 +18,7 @@ package com.forgerock.securebanking.openbanking.uk.rcs.testsupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.tpp.Tpp;
-import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRDomesticPaymentConsent;
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRPaymentConsent;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -56,7 +56,7 @@ public class WireMockStubHelper {
     }
 
     @SneakyThrows
-    public void stubGetPaymentConsent(FRDomesticPaymentConsent responseBody) {
+    public void stubGetPaymentConsent(FRPaymentConsent responseBody) {
         WIRE_MOCK_SERVER.stubFor(get(urlPathMatching("/idm/payment-consents/.*"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
@@ -87,7 +87,7 @@ public class WireMockStubHelper {
                         .withStatus(FOUND.value())));
     }
 
-    public void stubUpdatePaymentConsent(FRDomesticPaymentConsent expectedRequestBody) {
+    public void stubUpdatePaymentConsent(FRPaymentConsent expectedRequestBody) {
         WIRE_MOCK_SERVER.stubFor(put(urlPathMatching("/idm/payment-consents/.*"))
                 .withRequestBody(containing("\"accountId\":\"" + expectedRequestBody.getAccountId() + "\""))
                 // Note upper case OB JSON format

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFilePaymentConsentDataTestDataFactory.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFilePaymentConsentDataTestDataFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent;
+
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRFilePaymentConsentData;
+import org.joda.time.DateTime;
+
+import static com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRConsentStatusCode.AWAITINGAUTHORISATION;
+import static java.util.UUID.randomUUID;
+import static uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory.aValidOBWriteFile2DataInitiation;
+
+public class FRFilePaymentConsentDataTestDataFactory {
+
+    public static FRFilePaymentConsentData aValidFilePaymentConsentData() {
+        return aValidFilePaymentConsentDataBuilder(randomUUID().toString()).build();
+    }
+
+    public static FRFilePaymentConsentData aValidFilePaymentConsentData(String consentId) {
+        return aValidFilePaymentConsentDataBuilder(consentId).build();
+    }
+
+    public static FRFilePaymentConsentData.FRFilePaymentConsentDataBuilder aValidFilePaymentConsentDataBuilder(String consentId) {
+        return FRFilePaymentConsentData.builder()
+                .consentId(consentId)
+                .creationDateTime(DateTime.now())
+                .status(AWAITINGAUTHORISATION)
+                .statusUpdateDateTime(DateTime.now())
+                .initiation(aValidOBWriteFile2DataInitiation());
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFilePaymentConsentTestDataFactory.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFilePaymentConsentTestDataFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent;
+
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRFilePaymentConsent;
+
+import static com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent.FRFilePaymentConsentDataTestDataFactory.aValidFilePaymentConsentData;
+import static java.util.UUID.randomUUID;
+
+/**
+ * Test data factory for {@link FRFilePaymentConsent}.
+ */
+public class FRFilePaymentConsentTestDataFactory {
+
+    public static FRFilePaymentConsent aValidFRFilePaymentConsent() {
+        return aValidFRFilePaymentConsentBuilder(randomUUID().toString()).build();
+    }
+
+    public static FRFilePaymentConsent.FRFilePaymentConsentBuilder aValidFRFilePaymentConsentBuilder() {
+        return aValidFRFilePaymentConsentBuilder(randomUUID().toString());
+    }
+
+    public static FRFilePaymentConsent.FRFilePaymentConsentBuilder aValidFRFilePaymentConsentBuilder(String consentId) {
+        return FRFilePaymentConsent.builder()
+                .id(consentId)
+                .data(aValidFilePaymentConsentData(consentId))
+                .accountId(randomUUID().toString())
+                .resourceOwnerUsername(randomUUID().toString())
+                .oauth2ClientId(randomUUID().toString())
+                .oauth2ClientName("Tpp App Name");
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFundsConfirmationConsentDataTestDataFactory.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFundsConfirmationConsentDataTestDataFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent;
+
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRFundsConfirmationConsentData;
+import org.joda.time.DateTime;
+
+import static com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRConsentStatusCode.AWAITINGAUTHORISATION;
+import static java.util.UUID.randomUUID;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccount3;
+
+public class FRFundsConfirmationConsentDataTestDataFactory {
+
+    public static FRFundsConfirmationConsentData aValidFundsConfirmationConsentData() {
+        return aValidFundsConfirmationConsentDataBuilder(randomUUID().toString()).build();
+    }
+
+    public static FRFundsConfirmationConsentData aValidFundsConfirmationConsentData(String consentId) {
+        return aValidFundsConfirmationConsentDataBuilder(consentId).build();
+    }
+
+    public static FRFundsConfirmationConsentData.FRFundsConfirmationConsentDataBuilder aValidFundsConfirmationConsentDataBuilder(String consentId) {
+        return FRFundsConfirmationConsentData.builder()
+                .consentId(consentId)
+                .creationDateTime(DateTime.now())
+                .status(AWAITINGAUTHORISATION)
+                .statusUpdateDateTime(DateTime.now())
+                .debtorAccount(aValidOBCashAccount3());
+    }
+}

--- a/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFundsConfirmationConsentTestDataFactory.java
+++ b/securebanking-openbanking-uk-rcs-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rcs/testsupport/idm/dto/consent/FRFundsConfirmationConsentTestDataFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent;
+
+import com.forgerock.securebanking.openbanking.uk.rcs.client.idm.dto.consent.FRFundsConfirmationConsent;
+
+import static com.forgerock.securebanking.openbanking.uk.rcs.testsupport.idm.dto.consent.FRFundsConfirmationConsentDataTestDataFactory.aValidFundsConfirmationConsentData;
+import static java.util.UUID.randomUUID;
+
+/**
+ * Test data factory for {@link FRFundsConfirmationConsent}.
+ */
+public class FRFundsConfirmationConsentTestDataFactory {
+
+    public static FRFundsConfirmationConsent aValidFRFundsConfirmationConsent() {
+        return aValidFRFundsConfirmationConsentBuilder(randomUUID().toString()).build();
+    }
+
+    public static FRFundsConfirmationConsent.FRFundsConfirmationConsentBuilder aValidFRFundsConfirmationConsentBuilder() {
+        return aValidFRFundsConfirmationConsentBuilder(randomUUID().toString());
+    }
+
+    public static FRFundsConfirmationConsent.FRFundsConfirmationConsentBuilder aValidFRFundsConfirmationConsentBuilder(String consentId) {
+        return FRFundsConfirmationConsent.builder()
+                .id(consentId)
+                .data(aValidFundsConfirmationConsentData(consentId))
+                .accountId(randomUUID().toString())
+                .resourceOwnerUsername(randomUUID().toString())
+                .oauth2ClientId(randomUUID().toString())
+                .oauth2ClientName("Tpp App Name");
+    }
+}


### PR DESCRIPTION
### Submission of international payment consents

- Enabled submission of all payment types
- Fixed JSON types and `ConsentDetailsServiceDelegate`
- Additional integration tests to ensure all payment types are retrieved and submitted successfully.

**Issue**: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/66