### PR TITLE
66: Switched to spring-boot-maven-plugin for docker image creation

### DIFF
--- a/securebanking-openbanking-uk-rcs-sample/Dockerfile
+++ b/securebanking-openbanking-uk-rcs-sample/Dockerfile
@@ -1,0 +1,13 @@
+FROM adoptopenjdk/openjdk14:jre-14.0.2_12
+
+ARG JAR_FILE
+
+RUN mkdir /app
+RUN groupadd -r rcs && useradd -r -s /bin/false -g rcs rcs
+
+WORKDIR /app
+COPY $JAR_FILE /app/securebanking-openbanking-uk-rcs.jar
+RUN chown -R rcs:rcs /app
+USER rcs
+
+CMD ["java", "-jar", "securebanking-openbanking-uk-rcs.jar"]

--- a/securebanking-openbanking-uk-rcs-sample/docker/docker-compose-git.yml
+++ b/securebanking-openbanking-uk-rcs-sample/docker/docker-compose-git.yml
@@ -19,7 +19,7 @@ services:
 
   securebanking-config-server:
     container_name: securebanking-config-server
-    image: eu.gcr.io/openbanking-214714/securebanking/securebanking-config-server:latest
+    image: eu.gcr.io/sbat-gcr-develop/securebanking/spring-config-server:latest
     environment:
       - SSH_KEY=${GIT_SSH_KEY}
       - SPRING_CLOUD_CONFIG_SERVER_GIT_URI=git@github.com:SecureBankingAcceleratorToolkit/securebanking-openbanking-spring-config.git
@@ -29,7 +29,7 @@ services:
 
   rcs-service:
     container_name: rcs-service
-    image: eu.gcr.io/openbanking-214714/securebanking/uk-ob-rcs:latest
+    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rcs:latest
     ports:
       - 8080:8080
     environment:
@@ -47,7 +47,7 @@ services:
 
   rs-simulator:
     container_name: rs-simulator
-    image: eu.gcr.io/openbanking-214714/securebanking/uk-ob-rs-simulator:latest
+    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs:latest
     ports:
       - 8081:8080
     environment:

--- a/securebanking-openbanking-uk-rcs-sample/docker/docker-compose.yml
+++ b/securebanking-openbanking-uk-rcs-sample/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   securebanking-config-server:
     container_name: securebanking-config-server
     hostname: securebanking-config-server
-    image: eu.gcr.io/openbanking-214714/securebanking/securebanking-config-server:latest
+    image: eu.gcr.io/sbat-gcr-develop/securebanking/spring-config-server:latest
     environment:
       - SPRING_PROFILES_ACTIVE=native
       - CONFIG_SERVER_SEARCH_LOCATIONS=file:///home/config
@@ -31,7 +31,7 @@ services:
 
   rcs-service:
     container_name: rcs-service
-    image: eu.gcr.io/openbanking-214714/securebanking/uk-ob-rcs:latest
+    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rcs:latest
     ports:
       - 8080:8080
     environment:
@@ -49,7 +49,7 @@ services:
 
   rs-simulator:
     container_name: rs-simulator
-    image: eu.gcr.io/openbanking-214714/securebanking/uk-ob-rs-simulator:latest
+    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs:latest
     ports:
       - 8081:8080
     environment:

--- a/securebanking-openbanking-uk-rcs-sample/pom.xml
+++ b/securebanking-openbanking-uk-rcs-sample/pom.xml
@@ -109,36 +109,40 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
-                    <from>
-                        <image>adoptopenjdk/openjdk14:jre-14.0.2_12</image>
-                    </from>
-                    <to>
-                        <image>eu.gcr.io/openbanking-214714/securebanking/uk-ob-rcs</image>
-                        <tags>
-                            <tag>${project.version}</tag>
-                            <tag>latest</tag>
-                        </tags>
-                    </to>
-                    <container>
-                        <!-- Using this setting means the image is not truly reproducible, as a new one is created each
-                        time. However it gives it a proper creation date in the registry (rather than 1 Jan 1970!) -->
-                        <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
-                        <jvmFlags>
-                            <jvmFlag>-Xms512m</jvmFlag>
-                            <jvmFlag>-Xdebug</jvmFlag>
-                        </jvmFlags>
-                    </container>
+                    <mainClass>com.forgerock.securebanking.openbanking.uk.rcs.RcsApplication</mainClass>
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>deploy</phase>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <skipPush>false</skipPush>
+                    <repository>eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rcs</repository>
+                    <buildArgs>
+                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                    </buildArgs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build</id>
+                        <phase>package</phase>
                         <goals>
                             <goal>build</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>push</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Switch to spring-boot-maven-plugin, instead of jib, for docker image creation

Using SBA GCR docker registry.

**Issue**: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/66